### PR TITLE
fix LYS-PLP link

### DIFF
--- a/links_and_mods.cif
+++ b/links_and_mods.cif
@@ -5256,7 +5256,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-LYS-PLP 1 NZ 2 C4A DOUBLE 1.270 0.0174
+LYS-PLP 1 NZ 2 C4A DOUBLE 1.269 0.0164
 
 loop_
 _chem_link_angle.link_id
@@ -5268,9 +5268,9 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-LYS-PLP 1 CE 1 NZ 2 C4A 118.382 1.50
-LYS-PLP 2 C4 2 C4A 1 NZ 122.438 1.52
-LYS-PLP 1 NZ 2 C4A 2 H4A 118.729 1.50
+LYS-PLP 1 CE 1 NZ 2 C4A 118.355 1.81
+LYS-PLP 2 C4 2 C4A 1 NZ 122.167 2.29
+LYS-PLP 1 NZ 2 C4A 2 H4A 118.654 1.50
 
 loop_
 _chem_link_tor.link_id
@@ -5286,7 +5286,9 @@ _chem_link_tor.atom_id_4
 _chem_link_tor.value_angle
 _chem_link_tor.value_angle_esd
 _chem_link_tor.period
-LYS-PLP sp2_sp2_1 2 C4 2 C4A 1 NZ 1 CE 180.000 5.00 2
+LYS-PLP sp2_sp2_1 2 C4 2 C4A 1 NZ 1 CE 180.000 5.0 2
+LYS-PLP sp2_sp2_2 2 C3 2 C4 2 C4A 1 NZ 180.000 5.0 2
+LYS-PLP sp2_sp3_2 2 C4A 1 NZ 1 CE 1 CD 120.000 20.0 6
 
 loop_
 _chem_link_plane.link_id
@@ -11442,7 +11444,7 @@ _chem_mod_atom.new_charge
 LYSmod4 delete HZ1 . H H 0
 LYSmod4 delete HZ2 . H H 0
 LYSmod4 delete HZ3 . H H 0
-LYSmod4 change NZ . N N 0
+LYSmod4 change NZ . N N20 0
 
 loop_
 _chem_mod_bond.mod_id
@@ -11457,7 +11459,7 @@ _chem_mod_bond.new_value_dist_nucleus_esd
 LYSmod4 delete NZ HZ1 single . . . .
 LYSmod4 delete NZ HZ2 single . . . .
 LYSmod4 delete NZ HZ3 single . . . .
-LYSmod4 change CE NZ single 1.462 0.0100 1.462 0.0100
+LYSmod4 change CD CE single 1.524 0.0136 1.524 0.0136
 
 loop_
 _chem_mod_angle.mod_id
@@ -11483,7 +11485,7 @@ _chem_mod_tor.atom_id_3
 _chem_mod_tor.atom_id_4
 _chem_mod_tor.new_value_angle
 _chem_mod_tor.new_value_angle_esd
-LYSmod4 delete CD CE NZ HZ1 . .
+LYSmod4 delete CD CE NZ HZ3 . .
 
 data_mod_PLPmod1
 loop_
@@ -11507,8 +11509,6 @@ _chem_mod_bond.new_value_dist_esd
 _chem_mod_bond.new_value_dist_nucleus
 _chem_mod_bond.new_value_dist_nucleus_esd
 PLPmod1 delete C4A O4A double . . . .
-PLPmod1 change C4 C4A single 1.459 0.0148 1.459 0.0148
-PLPmod1 change C4A H4A single 0.975 0.010 1.082 0.013
 
 loop_
 _chem_mod_angle.mod_id
@@ -11520,7 +11520,7 @@ _chem_mod_angle.new_value_angle
 _chem_mod_angle.new_value_angle_esd
 PLPmod1 delete C4 C4A O4A . .
 PLPmod1 delete O4A C4A H4A . .
-PLPmod1 change C4 C4A H4A 118.833 1.50
+PLPmod1 change C4 C4A H4A 119.178 1.50
 
 loop_
 _chem_mod_tor.mod_id
@@ -11543,17 +11543,6 @@ PLPmod1 delete plan-2 C4 0.020
 PLPmod1 delete plan-2 C4A 0.020
 PLPmod1 delete plan-2 H4A 0.020
 PLPmod1 delete plan-2 O4A 0.020
-PLPmod1 delete plan-1 C2 0.020
-PLPmod1 delete plan-1 C2A 0.020
-PLPmod1 delete plan-1 C3 0.020
-PLPmod1 delete plan-1 C4 0.020
-PLPmod1 delete plan-1 C4A 0.020
-PLPmod1 delete plan-1 C5 0.020
-PLPmod1 delete plan-1 C5A 0.020
-PLPmod1 delete plan-1 C6 0.020
-PLPmod1 delete plan-1 H6 0.020
-PLPmod1 delete plan-1 N1 0.020
-PLPmod1 delete plan-1 O3 0.020
 
 data_mod_TRPmod1
 loop_

--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -41597,7 +41597,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-LYS-PLP 1 NZ 2 C4A DOUBLE 1.270 0.0174
+LYS-PLP 1 NZ 2 C4A DOUBLE 1.269 0.0164
 
 loop_
 _chem_link_angle.link_id
@@ -41609,9 +41609,9 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-LYS-PLP 1 CE 1 NZ 2 C4A 118.382 1.50
-LYS-PLP 2 C4 2 C4A 1 NZ 122.438 1.52
-LYS-PLP 1 NZ 2 C4A 2 H4A 118.729 1.50
+LYS-PLP 1 CE 1 NZ 2 C4A 118.355 1.81
+LYS-PLP 2 C4 2 C4A 1 NZ 122.167 2.29
+LYS-PLP 1 NZ 2 C4A 2 H4A 118.654 1.50
 
 loop_
 _chem_link_tor.link_id
@@ -41627,7 +41627,9 @@ _chem_link_tor.atom_id_4
 _chem_link_tor.value_angle
 _chem_link_tor.value_angle_esd
 _chem_link_tor.period
-LYS-PLP sp2_sp2_1 2 C4 2 C4A 1 NZ 1 CE 180.000 5.00 2
+LYS-PLP sp2_sp2_1 2 C4 2 C4A 1 NZ 1 CE 180.000 5.0 2
+LYS-PLP sp2_sp2_2 2 C3 2 C4 2 C4A 1 NZ 180.000 5.0 2
+LYS-PLP sp2_sp3_2 2 C4A 1 NZ 1 CE 1 CD 120.000 20.0 6
 
 loop_
 _chem_link_plane.link_id
@@ -47783,7 +47785,7 @@ _chem_mod_atom.new_charge
 LYSmod4 delete HZ1 . H H 0
 LYSmod4 delete HZ2 . H H 0
 LYSmod4 delete HZ3 . H H 0
-LYSmod4 change NZ . N N 0
+LYSmod4 change NZ . N N20 0
 
 loop_
 _chem_mod_bond.mod_id
@@ -47798,7 +47800,7 @@ _chem_mod_bond.new_value_dist_nucleus_esd
 LYSmod4 delete NZ HZ1 single . . . .
 LYSmod4 delete NZ HZ2 single . . . .
 LYSmod4 delete NZ HZ3 single . . . .
-LYSmod4 change CE NZ single 1.462 0.0100 1.462 0.0100
+LYSmod4 change CD CE single 1.524 0.0136 1.524 0.0136
 
 loop_
 _chem_mod_angle.mod_id
@@ -47824,7 +47826,7 @@ _chem_mod_tor.atom_id_3
 _chem_mod_tor.atom_id_4
 _chem_mod_tor.new_value_angle
 _chem_mod_tor.new_value_angle_esd
-LYSmod4 delete CD CE NZ HZ1 . .
+LYSmod4 delete CD CE NZ HZ3 . .
 
 data_mod_PLPmod1
 loop_
@@ -47848,8 +47850,6 @@ _chem_mod_bond.new_value_dist_esd
 _chem_mod_bond.new_value_dist_nucleus
 _chem_mod_bond.new_value_dist_nucleus_esd
 PLPmod1 delete C4A O4A double . . . .
-PLPmod1 change C4 C4A single 1.459 0.0148 1.459 0.0148
-PLPmod1 change C4A H4A single 0.975 0.010 1.082 0.013
 
 loop_
 _chem_mod_angle.mod_id
@@ -47861,7 +47861,7 @@ _chem_mod_angle.new_value_angle
 _chem_mod_angle.new_value_angle_esd
 PLPmod1 delete C4 C4A O4A . .
 PLPmod1 delete O4A C4A H4A . .
-PLPmod1 change C4 C4A H4A 118.833 1.50
+PLPmod1 change C4 C4A H4A 119.178 1.50
 
 loop_
 _chem_mod_tor.mod_id
@@ -47884,17 +47884,6 @@ PLPmod1 delete plan-2 C4 0.020
 PLPmod1 delete plan-2 C4A 0.020
 PLPmod1 delete plan-2 H4A 0.020
 PLPmod1 delete plan-2 O4A 0.020
-PLPmod1 delete plan-1 C2 0.020
-PLPmod1 delete plan-1 C2A 0.020
-PLPmod1 delete plan-1 C3 0.020
-PLPmod1 delete plan-1 C4 0.020
-PLPmod1 delete plan-1 C4A 0.020
-PLPmod1 delete plan-1 C5 0.020
-PLPmod1 delete plan-1 C5A 0.020
-PLPmod1 delete plan-1 C6 0.020
-PLPmod1 delete plan-1 H6 0.020
-PLPmod1 delete plan-1 N1 0.020
-PLPmod1 delete plan-1 O3 0.020
 
 data_mod_TRPmod1
 loop_

--- a/p/PLP.cif
+++ b/p/PLP.cif
@@ -1,4 +1,3 @@
-#
 data_comp_list
 loop_
 _chem_comp.id
@@ -8,77 +7,109 @@ _chem_comp.group
 _chem_comp.number_atoms_all
 _chem_comp.number_atoms_nh
 _chem_comp.desc_level
-PLP     PLP      "PYRIDOXAL-5'-PHOSPHATE"     NON-POLYMER     24     16     .     
-#
+PLP PLP "PYRIDOXAL-5'-PHOSPHATE" NON-POLYMER 24 16 .
+
 data_comp_PLP
-#
+
 loop_
 _chem_comp_atom.comp_id
 _chem_comp_atom.atom_id
+_chem_comp_atom.alt_atom_id
 _chem_comp_atom.type_symbol
 _chem_comp_atom.type_energy
 _chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
-PLP     N1      N       NRD6    0       -14.349     14.133      -7.922      
-PLP     C2      C       CR6     0       -13.036     14.180      -7.687      
-PLP     C2A     C       CH3     0       -12.425     15.509      -7.369      
-PLP     C3      C       CR6     0       -12.261     13.000      -7.741      
-PLP     O3      O       OH1     0       -10.904     13.013      -7.504      
-PLP     C4      C       CR6     0       -12.891     11.771      -8.047      
-PLP     C4A     C       C1      0       -12.092     10.543      -8.105      
-PLP     O4A     O       O       0       -11.093     10.379      -8.767      
-PLP     C5      C       CR6     0       -14.279     11.764      -8.290      
-PLP     C6      C       CR16    0       -14.950     12.958      -8.215      
-PLP     C5A     C       CH2     0       -15.027     10.500      -8.621      
-PLP     O4P     O       O2      0       -15.090     9.616       -7.458      
-PLP     P       P       P       0       -15.802     8.170       -7.537      
-PLP     O1P     O       O       0       -14.929     7.329       -8.450      
-PLP     O2P     O       OP      -1      -15.838     7.649       -6.113      
-PLP     O3P     O       OP      -1      -17.184     8.420       -8.109      
-PLP     H2A1    H       H       0       -11.473     15.414      -7.212      
-PLP     H2A2    H       H       0       -12.846     15.874      -6.573      
-PLP     H2A3    H       H       0       -12.568     16.115      -8.113      
-PLP     HO3     H       H       0       -10.588     12.646      -6.792      
-PLP     H4A     H       H       0       -12.388     9.814       -7.573      
-PLP     H6      H       H       0       -15.872     12.966      -8.373      
-PLP     H5A1    H       H       0       -14.580     10.029      -9.357      
-PLP     H5A2    H       H       0       -15.942     10.714      -8.906      
+PLP N1   N1   N N20  0  -1.750 1.637  0.279
+PLP C2   C2   C CR6  0  -2.365 0.534  -0.126
+PLP C2A  C2A  C CH3  0  -3.814 0.625  -0.493
+PLP C3   C3   C CR6  0  -1.688 -0.696 -0.202
+PLP O3   O3   O OH1  0  -2.463 -1.730 -0.630
+PLP C4   C4   C CR6  0  -0.321 -0.764 0.152
+PLP C4A  C4A  C C1   0  0.377  -2.058 0.064
+PLP O4A  O4A  O O    0  -0.125 -3.102 -0.294
+PLP C5   C5   C CR6  0  0.311  0.426  0.576
+PLP C6   C6   C CR16 0  -0.448 1.585  0.616
+PLP C5A  C5A  C CH2  0  1.763  0.495  0.980
+PLP O4P  O4P  O O2   0  2.637  0.324  -0.180
+PLP P    P    P P    0  4.250  0.217  -0.059
+PLP O1P  O1P  O O    0  4.532  -1.002 0.807
+PLP O2P  O2P  O OP   -1 4.754  0.050  -1.484
+PLP O3P  O3P  O OP   -1 4.718  1.517  0.578
+PLP H2A1 H2A1 H H    0  -3.947 0.318  -1.402
+PLP H2A2 H2A2 H H    0  -4.121 1.543  -0.425
+PLP H2A3 H2A3 H H    0  -4.338 0.074  0.108
+PLP HO3  HO3  H H    0  -2.057 -2.480 -0.678
+PLP H4A  H4A  H H    0  1.290  -2.090 0.303
+PLP H6   H6   H H    0  -0.040 2.384  0.896
+PLP H5A1 H5A1 H H    0  1.965  -0.210 1.640
+PLP H5A2 H5A2 H H    0  1.968  1.368  1.392
+
+loop_
+_chem_comp_acedrg.comp_id
+_chem_comp_acedrg.atom_id
+_chem_comp_acedrg.atom_type
+PLP N1   N[6a](C[6a]C[6a]C)(C[6a]C[6a]H){1|C<3>,1|C<4>,1|O<2>}
+PLP C2   C[6a](C[6a]C[6a]O)(N[6a]C[6a])(CH3){1|H<1>,2|C<3>}
+PLP C2A  C(C[6a]C[6a]N[6a])(H)3
+PLP C3   C[6a](C[6a]C[6a]C)(C[6a]N[6a]C)(OH){1|C<3>,1|C<4>}
+PLP O3   O(C[6a]C[6a]2)(H)
+PLP C4   C[6a](C[6a]C[6a]C)(C[6a]C[6a]O)(CHO){1|C<4>,1|H<1>,1|N<2>}
+PLP C4A  C(C[6a]C[6a]2)(H)(O)
+PLP O4A  O(CC[6a]H)
+PLP C5   C[6a](C[6a]C[6a]C)(C[6a]N[6a]H)(CHHO){1|C<3>,1|O<2>}
+PLP C6   C[6a](C[6a]C[6a]C)(N[6a]C[6a])(H){1|C<4>,2|C<3>}
+PLP C5A  C(C[6a]C[6a]2)(OP)(H)2
+PLP O4P  O(CC[6a]HH)(PO3)
+PLP P    P(OC)(O)3
+PLP O1P  O(PO3)
+PLP O2P  O(PO3)
+PLP O3P  O(PO3)
+PLP H2A1 H(CC[6a]HH)
+PLP H2A2 H(CC[6a]HH)
+PLP H2A3 H(CC[6a]HH)
+PLP HO3  H(OC[6a])
+PLP H4A  H(CC[6a]O)
+PLP H6   H(C[6a]C[6a]N[6a])
+PLP H5A1 H(CC[6a]HO)
+PLP H5A2 H(CC[6a]HO)
+
 loop_
 _chem_comp_bond.comp_id
 _chem_comp_bond.atom_id_1
 _chem_comp_bond.atom_id_2
-_chem_comp_bond.type
-_chem_comp_bond.aromatic
+_chem_comp_bond.value_order
+_chem_comp_bond.pdbx_aromatic_flag
 _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-PLP          N1          C2      DOUBLE       y     1.330  0.0101     1.330  0.0101
-PLP          N1          C6      SINGLE       y     1.349  0.0100     1.349  0.0100
-PLP          C2         C2A      SINGLE       n     1.494  0.0100     1.494  0.0100
-PLP          C2          C3      SINGLE       y     1.400  0.0136     1.400  0.0136
-PLP          C3          O3      SINGLE       n     1.374  0.0155     1.374  0.0155
-PLP          C3          C4      DOUBLE       y     1.409  0.0100     1.409  0.0100
-PLP          C4         C4A      SINGLE       n     1.464  0.0111     1.464  0.0111
-PLP          C4          C5      SINGLE       y     1.403  0.0100     1.403  0.0100
-PLP         C4A         O4A      DOUBLE       n     1.210  0.0148     1.210  0.0148
-PLP          C5          C6      DOUBLE       y     1.368  0.0100     1.368  0.0100
-PLP          C5         C5A      SINGLE       n     1.503  0.0100     1.503  0.0100
-PLP         C5A         O4P      SINGLE       n     1.462  0.0104     1.462  0.0104
-PLP         O4P           P      SINGLE       n     1.614  0.0178     1.614  0.0178
-PLP           P         O1P      DOUBLE       n     1.517  0.0192     1.517  0.0192
-PLP           P         O2P      SINGLE       n     1.517  0.0192     1.517  0.0192
-PLP           P         O3P      SINGLE       n     1.517  0.0192     1.517  0.0192
-PLP         C2A        H2A1      SINGLE       n     1.089  0.0100     0.971  0.0138
-PLP         C2A        H2A2      SINGLE       n     1.089  0.0100     0.971  0.0138
-PLP         C2A        H2A3      SINGLE       n     1.089  0.0100     0.971  0.0138
-PLP          O3         HO3      SINGLE       n     0.966  0.0059     0.861  0.0200
-PLP         C4A         H4A      SINGLE       n     1.082  0.0130     0.949  0.0200
-PLP          C6          H6      SINGLE       n     1.082  0.0130     0.935  0.0200
-PLP         C5A        H5A1      SINGLE       n     1.089  0.0100     0.982  0.0107
-PLP         C5A        H5A2      SINGLE       n     1.089  0.0100     0.982  0.0107
+PLP N1  C2   DOUBLE y 1.328 0.0100 1.328 0.0100
+PLP N1  C6   SINGLE y 1.348 0.0100 1.348 0.0100
+PLP C2  C2A  SINGLE n 1.496 0.0100 1.496 0.0100
+PLP C2  C3   SINGLE y 1.405 0.0100 1.405 0.0100
+PLP C3  O3   SINGLE n 1.355 0.0122 1.355 0.0122
+PLP C3  C4   DOUBLE y 1.404 0.0113 1.404 0.0113
+PLP C4  C4A  SINGLE n 1.467 0.0100 1.467 0.0100
+PLP C4  C5   SINGLE y 1.405 0.0100 1.405 0.0100
+PLP C4A O4A  DOUBLE n 1.210 0.0167 1.210 0.0167
+PLP C5  C6   DOUBLE y 1.384 0.0145 1.384 0.0145
+PLP C5  C5A  SINGLE n 1.503 0.0100 1.503 0.0100
+PLP C5A O4P  SINGLE n 1.462 0.0100 1.462 0.0100
+PLP O4P P    SINGLE n 1.620 0.0143 1.620 0.0143
+PLP P   O1P  DOUBLE n 1.521 0.0200 1.521 0.0200
+PLP P   O2P  SINGLE n 1.521 0.0200 1.521 0.0200
+PLP P   O3P  SINGLE n 1.521 0.0200 1.521 0.0200
+PLP C2A H2A1 SINGLE n 1.092 0.0100 0.969 0.0191
+PLP C2A H2A2 SINGLE n 1.092 0.0100 0.969 0.0191
+PLP C2A H2A3 SINGLE n 1.092 0.0100 0.969 0.0191
+PLP O3  HO3  SINGLE n 0.966 0.0059 0.858 0.0200
+PLP C4A H4A  SINGLE n 1.085 0.0150 0.948 0.0200
+PLP C6  H6   SINGLE n 1.085 0.0150 0.940 0.0200
+PLP C5A H5A1 SINGLE n 1.092 0.0100 0.986 0.0200
+PLP C5A H5A2 SINGLE n 1.092 0.0100 0.986 0.0200
+
 loop_
 _chem_comp_angle.comp_id
 _chem_comp_angle.atom_id_1
@@ -86,45 +117,46 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
-PLP          C2          N1          C6     119.423    1.60
-PLP          N1          C2         C2A     119.020    1.50
-PLP          N1          C2          C3     120.363    1.50
-PLP         C2A          C2          C3     120.617    1.50
-PLP          C2         C2A        H2A1     109.484    1.50
-PLP          C2         C2A        H2A2     109.484    1.50
-PLP          C2         C2A        H2A3     109.484    1.50
-PLP        H2A1         C2A        H2A2     109.339    1.66
-PLP        H2A1         C2A        H2A3     109.339    1.66
-PLP        H2A2         C2A        H2A3     109.339    1.66
-PLP          C2          C3          O3     120.185    3.00
-PLP          C2          C3          C4     119.630    1.50
-PLP          O3          C3          C4     120.185    3.00
-PLP          C3          O3         HO3     120.000    3.00
-PLP          C3          C4         C4A     119.703    1.50
-PLP          C3          C4          C5     118.922    1.50
-PLP         C4A          C4          C5     121.375    2.22
-PLP          C4         C4A         O4A     125.762    1.85
-PLP          C4         C4A         H4A     116.796    1.55
-PLP         O4A         C4A         H4A     117.442    1.69
-PLP          C4          C5          C6     118.395    1.50
-PLP          C4          C5         C5A     121.689    1.50
-PLP          C6          C5         C5A     119.916    1.59
-PLP          N1          C6          C5     123.267    1.50
-PLP          N1          C6          H6     118.102    1.50
-PLP          C5          C6          H6     118.631    1.50
-PLP          C5         C5A         O4P     110.538    2.24
-PLP          C5         C5A        H5A1     109.800    1.50
-PLP          C5         C5A        H5A2     109.800    1.50
-PLP         O4P         C5A        H5A1     108.933    1.90
-PLP         O4P         C5A        H5A2     108.933    1.90
-PLP        H5A1         C5A        H5A2     108.248    1.50
-PLP         C5A         O4P           P     121.496    2.55
-PLP         O4P           P         O1P     105.808    2.07
-PLP         O4P           P         O2P     105.808    2.07
-PLP         O4P           P         O3P     105.808    2.07
-PLP         O1P           P         O2P     112.864    1.69
-PLP         O1P           P         O3P     112.864    1.69
-PLP         O2P           P         O3P     112.864    1.69
+PLP C2   N1  C6   119.145 3.00
+PLP N1   C2  C2A  118.422 1.50
+PLP N1   C2  C3   121.162 1.50
+PLP C2A  C2  C3   120.415 1.50
+PLP C2   C2A H2A1 109.858 2.49
+PLP C2   C2A H2A2 109.858 2.49
+PLP C2   C2A H2A3 109.858 2.49
+PLP H2A1 C2A H2A2 109.327 3.00
+PLP H2A1 C2A H2A3 109.327 3.00
+PLP H2A2 C2A H2A3 109.327 3.00
+PLP C2   C3  O3   118.314 2.74
+PLP C2   C3  C4   119.252 1.50
+PLP O3   C3  C4   122.433 2.39
+PLP C3   O3  HO3  108.013 3.00
+PLP C3   C4  C4A  119.391 1.59
+PLP C3   C4  C5   118.809 1.50
+PLP C4A  C4  C5   121.800 3.00
+PLP C4   C4A O4A  125.098 2.92
+PLP C4   C4A H4A  117.258 1.50
+PLP O4A  C4A H4A  117.644 2.17
+PLP C4   C5  C6   118.248 3.00
+PLP C4   C5  C5A  121.638 1.63
+PLP C6   C5  C5A  120.115 2.42
+PLP N1   C6  C5   123.384 1.78
+PLP N1   C6  H6   117.901 1.50
+PLP C5   C6  H6   118.715 1.50
+PLP C5   C5A O4P  110.300 3.00
+PLP C5   C5A H5A1 109.826 1.50
+PLP C5   C5A H5A2 109.826 1.50
+PLP O4P  C5A H5A1 108.466 3.00
+PLP O4P  C5A H5A2 108.466 3.00
+PLP H5A1 C5A H5A2 108.241 1.50
+PLP C5A  O4P P    121.760 3.00
+PLP O4P  P   O1P  105.737 3.00
+PLP O4P  P   O2P  105.737 3.00
+PLP O4P  P   O3P  105.737 3.00
+PLP O1P  P   O2P  112.951 3.00
+PLP O1P  P   O3P  112.951 3.00
+PLP O2P  P   O3P  112.951 3.00
+
 loop_
 _chem_comp_tor.comp_id
 _chem_comp_tor.id
@@ -135,18 +167,19 @@ _chem_comp_tor.atom_id_4
 _chem_comp_tor.value_angle
 _chem_comp_tor.value_angle_esd
 _chem_comp_tor.period
-PLP       const_sp2_sp2_2         C2A          C2          N1          C6     180.000     5.0     2
-PLP              const_19          C5          C6          N1          C2       0.000    10.0     2
-PLP             sp3_sp3_1          C5         C5A         O4P           P     180.000    10.0     3
-PLP             sp3_sp3_6         C5A         O4P           P         O1P      60.000    10.0     3
-PLP             sp2_sp3_1          N1          C2         C2A        H2A1     150.000    10.0     6
-PLP       const_sp2_sp2_6         C2A          C2          C3          O3       0.000     5.0     2
-PLP             sp2_sp2_1          C2          C3          O3         HO3     180.000     5.0     2
-PLP              const_10          O3          C3          C4         C4A       0.000    10.0     2
-PLP             sp2_sp2_3          C3          C4         C4A         O4A     180.000     5.0     2
-PLP              const_14         C4A          C4          C5         C5A       0.000    10.0     2
-PLP             sp2_sp3_8          C4          C5         C5A         O4P     -90.000    10.0     6
-PLP              const_17         C5A          C5          C6          N1     180.000    10.0     2
+PLP const_0   C2A C2  N1  C6   180.000 0.0  1
+PLP const_1   C5  C6  N1  C2   0.000   0.0  1
+PLP sp3_sp3_1 C5  C5A O4P P    180.000 10.0 3
+PLP sp3_sp3_2 C5A O4P P   O1P  60.000  10.0 3
+PLP sp2_sp3_1 N1  C2  C2A H2A1 150.000 20.0 6
+PLP const_2   C2A C2  C3  O3   0.000   0.0  1
+PLP sp2_sp2_1 C2  C3  O3  HO3  180.000 5.0  2
+PLP const_3   O3  C3  C4  C4A  0.000   0.0  1
+PLP sp2_sp2_2 C3  C4  C4A O4A  180.000 5.0  2
+PLP const_4   C4A C4  C5  C5A  0.000   0.0  1
+PLP sp2_sp3_2 C4  C5  C5A O4P  -90.000 20.0 6
+PLP const_5   C5A C5  C6  N1   180.000 0.0  1
+
 loop_
 _chem_comp_chir.comp_id
 _chem_comp_chir.id
@@ -155,46 +188,61 @@ _chem_comp_chir.atom_id_1
 _chem_comp_chir.atom_id_2
 _chem_comp_chir.atom_id_3
 _chem_comp_chir.volume_sign
-PLP    chir_1    P    O4P    O2P    O3P    both
+PLP chir_1 P O4P O2P O3P both
+
 loop_
 _chem_comp_plane_atom.comp_id
 _chem_comp_plane_atom.plane_id
 _chem_comp_plane_atom.atom_id
 _chem_comp_plane_atom.dist_esd
-PLP    plan-1          C2   0.020
-PLP    plan-1         C2A   0.020
-PLP    plan-1          C3   0.020
-PLP    plan-1          C4   0.020
-PLP    plan-1         C4A   0.020
-PLP    plan-1          C5   0.020
-PLP    plan-1         C5A   0.020
-PLP    plan-1          C6   0.020
-PLP    plan-1          H6   0.020
-PLP    plan-1          N1   0.020
-PLP    plan-1          O3   0.020
-PLP    plan-2          C4   0.020
-PLP    plan-2         C4A   0.020
-PLP    plan-2         H4A   0.020
-PLP    plan-2         O4A   0.020
+PLP plan-1 C2  0.020
+PLP plan-1 C2A 0.020
+PLP plan-1 C3  0.020
+PLP plan-1 C4  0.020
+PLP plan-1 C4A 0.020
+PLP plan-1 C5  0.020
+PLP plan-1 C5A 0.020
+PLP plan-1 C6  0.020
+PLP plan-1 H6  0.020
+PLP plan-1 N1  0.020
+PLP plan-1 O3  0.020
+PLP plan-2 C4  0.020
+PLP plan-2 C4A 0.020
+PLP plan-2 H4A 0.020
+PLP plan-2 O4A 0.020
+
+loop_
+_chem_comp_ring_atom.comp_id
+_chem_comp_ring_atom.ring_serial_number
+_chem_comp_ring_atom.atom_id
+_chem_comp_ring_atom.is_aromatic_ring
+PLP ring-1 N1 YES
+PLP ring-1 C2 YES
+PLP ring-1 C3 YES
+PLP ring-1 C4 YES
+PLP ring-1 C5 YES
+PLP ring-1 C6 YES
+
 loop_
 _pdbx_chem_comp_descriptor.comp_id
 _pdbx_chem_comp_descriptor.type
 _pdbx_chem_comp_descriptor.program
 _pdbx_chem_comp_descriptor.program_version
 _pdbx_chem_comp_descriptor.descriptor
-PLP           SMILES              ACDLabs 10.04                                                                O=P(O)(O)OCc1cnc(c(O)c1C=O)C
-PLP SMILES_CANONICAL               CACTVS 3.341                                                              Cc1ncc(CO[P](O)(O)=O)c(C=O)c1O
-PLP           SMILES               CACTVS 3.341                                                              Cc1ncc(CO[P](O)(O)=O)c(C=O)c1O
-PLP SMILES_CANONICAL "OpenEye OEToolkits" 1.5.0                                                              Cc1c(c(c(cn1)COP(=O)(O)O)C=O)O
-PLP           SMILES "OpenEye OEToolkits" 1.5.0                                                              Cc1c(c(c(cn1)COP(=O)(O)O)C=O)O
-PLP            InChI                InChI  1.03 InChI=1S/C8H10NO6P/c1-5-8(11)7(3-10)6(2-9-5)4-15-16(12,13)14/h2-3,11H,4H2,1H3,(H2,12,13,14)
-PLP         InChIKey                InChI  1.03                                                                 NGVDGCNFYWLIFO-UHFFFAOYSA-N
+PLP SMILES           ACDLabs              10.04 "O=P(O)(O)OCc1cnc(c(O)c1C=O)C"
+PLP SMILES_CANONICAL CACTVS               3.341 "Cc1ncc(CO[P](O)(O)=O)c(C=O)c1O"
+PLP SMILES           CACTVS               3.341 "Cc1ncc(CO[P](O)(O)=O)c(C=O)c1O"
+PLP SMILES_CANONICAL "OpenEye OEToolkits" 1.5.0 "Cc1c(c(c(cn1)COP(=O)(O)O)C=O)O"
+PLP SMILES           "OpenEye OEToolkits" 1.5.0 "Cc1c(c(c(cn1)COP(=O)(O)O)C=O)O"
+PLP InChI            InChI                1.03  "InChI=1S/C8H10NO6P/c1-5-8(11)7(3-10)6(2-9-5)4-15-16(12,13)14/h2-3,11H,4H2,1H3,(H2,12,13,14)"
+PLP InChIKey         InChI                1.03  NGVDGCNFYWLIFO-UHFFFAOYSA-N
+
 loop_
-_pdbx_chem_comp_description_generator.comp_id
-_pdbx_chem_comp_description_generator.program_name
-_pdbx_chem_comp_description_generator.program_version
-_pdbx_chem_comp_description_generator.descriptor
-PLP acedrg               243         "dictionary generator"                  
-PLP acedrg_database      11          "data source"                           
-PLP rdkit                2017.03.2   "Chemoinformatics tool"
-PLP refmac5              5.8.0238    "optimization tool"                     
+_acedrg_chem_comp_descriptor.comp_id
+_acedrg_chem_comp_descriptor.program_name
+_acedrg_chem_comp_descriptor.program_version
+_acedrg_chem_comp_descriptor.type
+PLP acedrg          331       "dictionary generator"
+PLP acedrg_database 12        "data source"
+PLP rdkit           2023.03.3 "Chemoinformatics tool"
+PLP servalcat       0.4.146   'optimization tool'


### PR DESCRIPTION
PLPmod1 mistakenly removes plan-1, which should be retained (reported by @LucreziaCatapano and @drlemmus). Both PLP and LYS-PLP have been updated using Acedrg 331 with the following instruction. This PR now requires testing.
```
LINK: RES-NAME-1 LYS ATOM-NAME-1 NZ RES-NAME-2 PLP ATOM-NAME-2 C4A BOND-TYPE DOUBLE DELETE ATOM O4A 2
```